### PR TITLE
Fix resize bug

### DIFF
--- a/SmoothScroll.js
+++ b/SmoothScroll.js
@@ -146,6 +146,8 @@ function init() {
         observer = new MutationObserver(refresh);
         observer.observe(body, config);
 
+        addEvent('resize', refresh);
+
         if (root.offsetHeight <= windowHeight) {
             var clearfix = document.createElement('div');   
             clearfix.style.clear = 'both';


### PR DESCRIPTION
When you resize the browser viewport (e.g `Ctrl`+`-` or `Ctrl`+`+` or `Ctrl`+`Mouse Wheel`) sometimes the `fullPageElem` element don't adjust the `height` creating a space on the bottom of the page, then added to the event "onresize" it's fixed.
