### PR TITLE
The package name is invalid

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "smoothscroll",
+  "name": "smoothscroll-for-websites",
   "version": "1.4.1",
   "title": "SmoothScroll for websites",
   "description": "Smooth scrolling experience for websites. This is the standalone version of SmoothScroll for individual websites and themes. Mouse wheel, keyboard and touchpad scrolling all supported.",


### PR DESCRIPTION
The current package name in bower.json (smoothscroll) is different from the actual package which is registered on bower (smoothscroll-for-websites)
