### PR TITLE
Added callback option

### DIFF
--- a/SmoothScroll.js
+++ b/SmoothScroll.js
@@ -39,7 +39,8 @@ var defaultOptions = {
 
     // Other
     fixedBackground   : true, 
-    excluded          : ''    
+    excluded          : '',
+    callback          : null
 };
 
 var options = defaultOptions;
@@ -362,6 +363,10 @@ function wheel(event) {
         deltaY *= options.stepSize / 120;
     }
     
+    // If a callback is set, call it passing the triggering event as parameter
+    if (options.callback) {
+        options.callback(event);
+    }
     scrollArray(overflowing, deltaX, deltaY);
     event.preventDefault();
     scheduleClearCache();
@@ -461,6 +466,10 @@ function keydown(event) {
             return true; // a key we don't care about
     }
 
+    // If a callback is set, call it passing the triggering event as parameter
+    if (options.callback) {
+        options.callback(event);
+    }
     scrollArray(overflowing, x, y);
     event.preventDefault();
     scheduleClearCache();


### PR DESCRIPTION
I think it would be useful to have an optional callback function to set which is fired every time a scroll event occurs, as it gets tricky to catch scrolling events when SmoothScroll.js inites (as it stops the events from propagating)