### PR TITLE
Add firefox-support

### DIFF
--- a/SmoothScroll.js
+++ b/SmoothScroll.js
@@ -739,9 +739,10 @@ var isEdge    = /Edge/.test(userAgent); // thank you MS
 var isChrome  = /chrome/i.test(userAgent) && !isEdge; 
 var isSafari  = /safari/i.test(userAgent) && !isEdge; 
 var isMobile  = /mobile/i.test(userAgent);
+var isFirefox = /firefox/i.test(userAgent);
 var isIEWin7  = /Windows NT 6.1/i.test(userAgent) && /rv:11/i.test(userAgent);
 var isOldSafari = isSafari && (/Version\/8/i.test(userAgent) || /Version\/9/i.test(userAgent));
-var isEnabledForBrowser = (isChrome || isSafari || isIEWin7) && !isMobile;
+var isEnabledForBrowser = (isChrome || isSafari || isIEWin7 || isFirefox) && !isMobile;
 
 var supportsPassive = false;
 try {


### PR DESCRIPTION
Currently there is no check for firefox, but firefox supports mousewheel and would work.
So I´ve just added a check for firefox to enable it.